### PR TITLE
Fix hash key removal

### DIFF
--- a/lib/king_dta/account.rb
+++ b/lib/king_dta/account.rb
@@ -12,6 +12,7 @@ module KingDta
     attr_reader :bank_account_number, :bank_number
 
     def initialize(args={})
+      args = args.dup
 
       @bank_street = convert_text(args.delete(:bank_street))
       @bank_city = convert_text(args.delete(:bank_city))

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -15,6 +15,19 @@ describe KingDta::Account do
     }.should_not raise_error
   end
 
+  # KingDta::Acount.new tends to remove keys from supplied hashes, which breaks
+  # things when I create multiple DTAUS files at once.
+  it "should not remove data from hashes" do
+    sender = {:owner_street => "123 Random Street",
+              :bank_account_number => @ba.bank_account_number,
+              :bank_number => @ba.bank_number,
+              :owner_name => @ba.owner_name}
+
+    sender.keys.should include(:owner_street) # => true
+    KingDta::Account.new(sender)
+    sender.keys.should include(:owner_street) # => boom!
+  end
+
   it "should initialize a new dtazv account" do
     lambda{
       KingDta::Account.new(sender_opts)


### PR DESCRIPTION
`KingDta::Acount.new` strips keys from supplied hashes.

``` ruby
 sender = {
  :owner_street => "123 Random Street",
  :bank_account_number => "000111222",
  :bank_number => "12312312",
  :owner_name => "Richard Carsharing"}
sender.keys.include? :owner_name # => true
KingDta::Account.new(sender)
sender.keys.include? :owner_name # => false
```

This breaks some of our stuff, so I fixed it.
