### PR TITLE
Support for currencies others than 'EUR' and support to set the charge bearer

### DIFF
--- a/lib/king_dta/booking.rb
+++ b/lib/king_dta/booking.rb
@@ -8,17 +8,21 @@ module KingDta
     LASTSCHRIFT_EINZUGSERMAECHTIGUNG = '05000'
     UEBERWEISUNG_GUTSCHRIFT          = '51000'
 
-    attr_accessor :value, :account, :text, :account_key
+    attr_accessor :value, :account, :text, :account_key, :currency
     #Eine Buchung ist definiert durch:
     #- Konto (siehe Klasse Konto
     #- Betrag
     #  Der Betrag kann , oder . als Dezimaltrenner enthalten.
     #- optional Buchungstext
-    def initialize( account, value, text=nil, account_key=nil )
+    def initialize( account, value, text=nil, account_key=nil, currency="EUR" )
       raise Exception.new("Hey, a booking should have an Account") unless account.kind_of?( Account )
       @account = account
       @text = text ? convert_text( text ) : text
       @account_key = account_key
+      if currency.size != 3
+        raise Exception.new("currency code needs to be 3 chars. You gave me: #{currency.inspect}")
+      end
+      @currency = currency
       if value.is_a?(String)
         value = BigDecimal.new value.sub(',', '.')
       elsif value.is_a?(Numeric)
@@ -28,7 +32,7 @@ module KingDta
       end
       value = ( value * 100 ).to_i  #€-Cent
       if value == 0
-        raise Exception.new("A booking of 0.00 € makes no sence")
+        raise Exception.new("A booking of 0.00 #{@currency} makes no sense")
       elsif value > 0
         @value = value
         @pos   = true

--- a/lib/king_dta/booking.rb
+++ b/lib/king_dta/booking.rb
@@ -8,7 +8,7 @@ module KingDta
     LASTSCHRIFT_EINZUGSERMAECHTIGUNG = '05000'
     UEBERWEISUNG_GUTSCHRIFT          = '51000'
 
-    attr_accessor :value, :account, :text, :account_key, :currency
+    attr_accessor :value, :account, :text, :account_key, :currency, :charge_bearer_code
     #Eine Buchung ist definiert durch:
     #- Konto (siehe Klasse Konto
     #- Betrag

--- a/lib/king_dta/dtazv.rb
+++ b/lib/king_dta/dtazv.rb
@@ -225,7 +225,7 @@ module KingDta
       data2 += "%02i" % 0                                           # N 18 Weisungsschlüssel 3 (gem. Anhang 2)
       data2 += "%02i" % 0                                           # N 19 Weisungsschlüssel 4 (gem. Anhang 2 und 2a)
       data2 += '%025s' % ''                                         # N 20 Zusatzinformationen zum Weisungsschlüssel
-      data2 += "%02i" % 0                                           # PFLICHT 21 Entgeltregelung
+      data2 += "%02i" % (booking.charge_bearer_code || 0)           # PFLICHT 21 Entgeltregelung
       data2 += "%02i" % 13                                          # PFLICHT 22 Kennzeichnung der Zahlungsart     Gemäß Anhang 1; Zahlungen, die weder '11' noch '13' als Zahlungsartschlüssel enthalten
       data2 += '%027s' % ''                                         # KANN 23 Variabler Text nur für Auftraggeberabrechnung
       # i dont know what to do.

--- a/lib/king_dta/dtazv.rb
+++ b/lib/king_dta/dtazv.rb
@@ -216,7 +216,7 @@ module KingDta
       data2 += '%-035.35s' % booking.account.owner_zip_city
       data2 += '%070s' % ''                                         # KANN/PFLICHT 11 Ordervermerk
       data2 += '/%-034s' % booking.account.bank_iban                # PFLICHT 12 35 IBAN bzw. Kontonummer des
-      data2 += 'EUR'                                                # KANN/PFLICHT 13 3 Auftragswährung "EUR"
+      data2 += booking.currency                                     # KANN/PFLICHT 13 3 Auftragswährung (z.B. "EUR")
       data2 += '%014i' % booking.value.divmod(100)[0]               # PFLICHT 14a 14 Betrag (Vorkommastellen) Rechtsbündig
       data2 += '%02i0' % booking.value.divmod(100)[1]               # PFLICHT 14b 3 Betrag (Nachkommastellen) Linksbündig
       data2 += '%-0140s' % (booking.text || default_text)

--- a/spec/dtazv_spec.rb
+++ b/spec/dtazv_spec.rb
@@ -4,6 +4,19 @@ require 'spec_helper'
 # All Test DTAZV output strings are validated with sFirm => lokal Sparkassen Software
 
 describe KingDta::Dtazv do
+  context "support for non-EUR currency" do
+    before do
+      @dtazv = KingDta::Dtazv.new(Date.parse('2011-08-28'))
+      @dtazv.account = KingDta::Account.new sender_opts
+      @booking = KingDta::Booking.new(KingDta::Account.new(swiss_receiver), 235.42, nil, nil, "CHF")
+    end
+
+    # FIXME: Write better tests later
+    it "should at least not raise an error" do
+      @dtazv.add(@booking)
+      @dtazv.create
+    end
+  end
 
   before :each do
     @dtazv = KingDta::Dtazv.new(Date.parse('2011-08-28'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,19 @@ def receiver_opts
   }
 end
 
+def swiss_receiver
+  # Random data
+  {
+    :bank_iban => "CH6331142389293969079",
+    :bank_bic => "BPPBCHGGXXX",
+    :owner_name => "Muammar al-Gaddafi",
+    :owner_street => "Bitziusstrasse 40",
+    :owner_city => "Bern",
+    :owner_zip_code => "3000",
+    :owner_country_code => "CH"
+  }
+end
+
 def test_kto1
   opts = {
             :bank_account_number => '7828970037',


### PR DESCRIPTION
I implemented support for currencies others than 'EUR' and support for setting the charge bearer code (that is setting which party pays the transaction fees). Code has been tested in our production environment and works.
