### PR TITLE
Support for payments to the U.S.

### DIFF
--- a/lib/king_dta/booking.rb
+++ b/lib/king_dta/booking.rb
@@ -8,7 +8,7 @@ module KingDta
     LASTSCHRIFT_EINZUGSERMAECHTIGUNG = '05000'
     UEBERWEISUNG_GUTSCHRIFT          = '51000'
 
-    attr_accessor :value, :account, :text, :account_key, :currency, :charge_bearer_code
+    attr_accessor :value, :account, :text, :account_key, :currency, :charge_bearer_code, :payment_type
     #Eine Buchung ist definiert durch:
     #- Konto (siehe Klasse Konto
     #- Betrag

--- a/lib/king_dta/dtazv.rb
+++ b/lib/king_dta/dtazv.rb
@@ -215,7 +215,7 @@ module KingDta
       data2 += '%-035.35s' % booking.account.owner_street
       data2 += '%-035.35s' % booking.account.owner_zip_city
       data2 += '%070s' % ''                                         # KANN/PFLICHT 11 Ordervermerk
-      data2 += '/%-034s' % booking.account.bank_iban                # PFLICHT 12 35 IBAN bzw. Kontonummer des
+      data2 += '/%-034s' % (booking.account.bank_iban || booking.account.bank_account_number) # PFLICHT 12 35 IBAN bzw. Kontonummer des
       data2 += booking.currency                                     # KANN/PFLICHT 13 3 Auftragswährung (z.B. "EUR")
       data2 += '%014i' % booking.value.divmod(100)[0]               # PFLICHT 14a 14 Betrag (Vorkommastellen) Rechtsbündig
       data2 += '%02i0' % booking.value.divmod(100)[1]               # PFLICHT 14b 3 Betrag (Nachkommastellen) Linksbündig

--- a/lib/king_dta/dtazv.rb
+++ b/lib/king_dta/dtazv.rb
@@ -226,7 +226,7 @@ module KingDta
       data2 += "%02i" % 0                                           # N 19 Weisungsschlüssel 4 (gem. Anhang 2 und 2a)
       data2 += '%025s' % ''                                         # N 20 Zusatzinformationen zum Weisungsschlüssel
       data2 += "%02i" % (booking.charge_bearer_code || 0)           # PFLICHT 21 Entgeltregelung
-      data2 += "%02i" % 13                                          # PFLICHT 22 Kennzeichnung der Zahlungsart     Gemäß Anhang 1; Zahlungen, die weder '11' noch '13' als Zahlungsartschlüssel enthalten
+      data2 += "%02i" % (booking.payment_type || 13)                # PFLICHT 22 Kennzeichnung der Zahlungsart     Gemäß Anhang 1; Zahlungen, die weder '11' noch '13' als Zahlungsartschlüssel enthalten
       data2 += '%027s' % ''                                         # KANN 23 Variabler Text nur für Auftraggeberabrechnung
       # i dont know what to do.
       data2 += '%035s' % ''                                         # KANN/PFLICHT 24 35 Name und Telefonnummer sowie ggf. Stellvertretungsmeldung


### PR DESCRIPTION
In order to transfer money to the U.S. (and other countries), there need to be two more hacks.
- Set _Zahlungsartschlüssel_ (T.22) to `00` (= general purpose SWIFT transfer) instead of `13` (_EU-Standardüberweisung_)
- Use the bank account number instead of the IBAN.

There is one more bug:
Bank account numbers in other countries may be longer than 10 chars, and bank codes may be longer than 8 chars. As the DTAZV part uses `Account`, it breaks when they are. Maybe I'll fix this later.

No tests included, but works in production.
