### PR TITLE
Increase account number limit to 35 chars

### DIFF
--- a/lib/king_dta/account.rb
+++ b/lib/king_dta/account.rb
@@ -49,7 +49,7 @@ module KingDta
     def bank_account_number=(number)
       raise ArgumentError.new('Bank account number cannot be nil') if number.nil?
       nr_str = "#{number}".gsub(/\s/,'')
-      raise ArgumentError.new('Bank account number too long, max 10 allowed') if nr_str.length > 10
+      raise ArgumentError.new('Bank account number too long, max 35 allowed') if nr_str.length > 35
       raise ArgumentError.new('Bank account number cannot be 0') if nr_str == '0'
 
       @bank_account_number = nr_str.to_i

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -58,11 +58,11 @@ describe KingDta::Account do
 
   it "should fail if bank account number is invalid" do
     lambda{
-      KingDta::Account.new(:bank_account_number => 123456789011123456789011123456789011,
+      KingDta::Account.new(:bank_account_number => ('1' * 36).to_i,
                            :bank_number => @ba.bank_number,
                            :owner_name => @ba.owner_name)
 
-    }.should raise_error(ArgumentError, 'Bank account number too long, max 10 allowed')
+    }.should raise_error(ArgumentError, 'Bank account number too long, max 35 allowed')
   end
 
   it "should fail if bank account number is nil" do


### PR DESCRIPTION
Some countries need an account number with more than 10 chars. The DTAZV spec says account numbers can be up to 35 digits long.

This works fine for us but I am not sure whether it breaks other things. It might need more tests / restrictions than currently implemented.
